### PR TITLE
Fix buffer inconsistency

### DIFF
--- a/binary/binary_reader.py
+++ b/binary/binary_reader.py
@@ -28,7 +28,7 @@ class BinaryReader:
         """Constructs a BinaryReader with the given buffer and endianness and sets its position to 0.\n
         If buffer is not given, a new bytearray() is created. If endianness is not given, it is set to little endian.
         """
-        self.__buf = buffer if type(buffer) is bytearray else bytearray(buffer)
+        self.__buf = bytearray(buffer)
         self.__big_end = big_endian
         self.__idx = 0
 
@@ -42,7 +42,7 @@ class BinaryReader:
 
     def buffer(self) -> bytearray:
         """Returns the buffer as a bytearray."""
-        return self.__buf if type(self.__buf) is bytearray else bytearray(self.__buf)
+        return bytearray(self.__buf)
 
     def pad(self, size: int) -> None:
         """Extends the buffer by 0s with the given size."""


### PR DESCRIPTION
Since we have methods to explicitly modify the inner buffer, we should
avoid sharing the reference by making sure we make a copy when
constructing the object and when returning its buffer.

I don't know if sharing the buffer is something you planned, but it can have some side effects like this one:
```py
my_bytearray = bytearray([0, 1, 2, 3])
br = BinaryReader(my_bytearray)

print(br.size())
my_bytearray.append(99)
print(br.size())

br_bytearray = br.buffer()
br_bytearray.append(0x99)
print(br.size())
```
```
4
5
6
```

Which means we're unexpectedly modifying internal buffer of the BinaryReader object, and that can have some side effects.